### PR TITLE
readme fix for building equihash verifier

### DIFF
--- a/aion_solo_pool/README.md
+++ b/aion_solo_pool/README.md
@@ -52,6 +52,10 @@ Eg. Using default settings the configuration should be:
 #### 3) Compile the Equihash Verifier
 
 - Navigate to ```local_modules/equihashverify```
+- Install npm dependencies
+```
+npm install
+```
 - Configure node-gyp to build the verifier by running the command: 
 ```
 node-gyp configure


### PR DESCRIPTION
I was not able to build equihashverify without some npm dependencies and I think this step was missed.