### PR TITLE
configure.sh: always use local node.js

### DIFF
--- a/aion_solo_pool/configure.sh
+++ b/aion_solo_pool/configure.sh
@@ -26,7 +26,7 @@ make -C ./redis
 # Build NPM 
 echo -e "\e[32mInstalling NPM modules."
 tput sgr0
-export PATH=$PATH:$PWD/node/bin
+export PATH=$PWD/node/bin:$PATH
 npm install
 
 # Clean


### PR DESCRIPTION
If the system already has a node.js installation, configure.sh uses that one instead of the local copy